### PR TITLE
Fix brew install error.

### DIFF
--- a/Formula/packageddataviewer.rb
+++ b/Formula/packageddataviewer.rb
@@ -1,9 +1,9 @@
 class Packageddataviewer < Formula
   desc "A CLI for SQLite querying"
-  homepage https://github.com/alexpyoung/PackagedDataViewer
-  url https://github.com/alexpyoung/PackagedDataViewer/releases/download/1.2.0/PackagedDataViewer-1.2.0.tar.gz
-  sha256 a5122296ebf60847746e27d41c6d82904ce630bc78e692ba6139c144b6927d26
-  version 1.2.0
+  homepage "https://github.com/alexpyoung/PackagedDataViewer"
+  url "https://github.com/alexpyoung/PackagedDataViewer/releases/download/1.2.0/PackagedDataViewer-1.2.0.tar.gz"
+  sha256 "a5122296ebf60847746e27d41c6d82904ce630bc78e692ba6139c144b6927d26"
+  version "1.2.0"
   bottle :unneeded
   def install
     bin.install "packageddataviewer"

--- a/Formula/packageddataviewer.rb
+++ b/Formula/packageddataviewer.rb
@@ -2,7 +2,7 @@ class Packageddataviewer < Formula
   desc "A CLI for SQLite querying"
   homepage "https://github.com/alexpyoung/PackagedDataViewer"
   url "https://github.com/alexpyoung/PackagedDataViewer/releases/download/1.2.0/PackagedDataViewer-1.2.0.tar.gz"
-  sha256 "a5122296ebf60847746e27d41c6d82904ce630bc78e692ba6139c144b6927d26"
+  sha256 "76a95e3a9aaf7d034e6c188c5698ce83e9ef6ae305b8dd9ced5599d04f7f9e3b"
   version "1.2.0"
   bottle :unneeded
   def install


### PR DESCRIPTION
@alexpyoung I got the error below when trying to install. I think this should fix it! 😃 

```
 ~  brew install alexpyoung/tools/packageddataviewer                                                                                 Thu Apr 18 17:25:43 2019
==> Tapping alexpyoung/tools
Cloning into '/usr/local/Homebrew/Library/Taps/alexpyoung/homebrew-tools'...
remote: Enumerating objects: 6, done.
remote: Counting objects: 100% (6/6), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 6 (delta 0), reused 5 (delta 0), pack-reused 0
Unpacking objects: 100% (6/6), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/alexpyoung/homebrew-tools/Formula/packageddataviewer.rb
packageddataviewer: /usr/local/Homebrew/Library/Taps/alexpyoung/homebrew-tools/Formula/packageddataviewer.rb:3: unknown regexp options - gthb
/usr/local/Homebrew/Library/Taps/alexpyoung/homebrew-tools/Formula/packageddataviewer.rb:4: unknown regexp options - gthb
/usr/local/Homebrew/Library/Taps/alexpyoung/homebrew-tools/Formula/packageddataviewer.rb:4: unexpected fraction part after numeric literal
...ataViewer/releases/download/1.2.0/PackagedDataViewer-1.2.0.t...
...                               ^
/usr/local/Homebrew/Library/Taps/alexpyoung/homebrew-tools/Formula/packageddataviewer.rb:4: syntax error, unexpected tCONSTANT, expecting keyword_end
...wnload/1.2.0/PackagedDataViewer-1.2.0.tar.gz
...                               ^
/usr/local/Homebrew/Library/Taps/alexpyoung/homebrew-tools/Formula/packageddataviewer.rb:4: unexpected fraction part after numeric literal
...ad/1.2.0/PackagedDataViewer-1.2.0.tar.gz
...                               ^
/usr/local/Homebrew/Library/Taps/alexpyoung/homebrew-tools/Formula/packageddataviewer.rb:4: syntax error, unexpected tIDENTIFIER, expecting keyword_end
....0/PackagedDataViewer-1.2.0.tar.gz
...                               ^
/usr/local/Homebrew/Library/Taps/alexpyoung/homebrew-tools/Formula/packageddataviewer.rb:6: unexpected fraction part after numeric literal
  version 1.2.0
             ^
/usr/local/Homebrew/Library/Taps/alexpyoung/homebrew-tools/Formula/packageddataviewer.rb:7: syntax error, unexpected tIDENTIFIER, expecting keyword_end
  bottle :unneeded
        ^
Error: Cannot tap alexpyoung/tools: invalid syntax in tap!
```